### PR TITLE
Preserve article by passing ID to the next page

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -11,7 +11,6 @@ router.use(bodyParser.urlencoded({ extended: true }));
 //GLOBAL VARIABLES//
 var url = 'https://www.reddit.com/r/theonion+nottheonion/top/.json?t=month&limit=100'
 var postIndex = 0
-var headlineData = ''
 var resultText = ''
 var articleLink = ''
 var redditLink = ''
@@ -19,11 +18,16 @@ var correctGuesses = 0
 var wrongGuesses = 0
 var userScore = 0
 var headlines
+var headlineLookup = {}
 
 //Make Reddit API call, return all data
 request(url, { json: true }, (err, res, body) => {
     headlines = body.data.children
     console.log("Number of Posts: "+headlines.length)
+});
+
+headlines.forEach(function (headline) {
+    headlineLookup[headline.data.id] = headline.data;
 });
 
 //GLOBAL FUNCTIONS//
@@ -32,21 +36,26 @@ function getRandomInt(max) {
 };
 function getNewHeadline() {
     postIndex = getRandomInt(headlines.length)  //Used to pick a post from json array gathered from Reddit
-    headlineData = headlines[postIndex].data
+    return headlines[postIndex].data
 };
+function getHeadline(id) {
+    return headlineLookup[id];
+}
 
 //Index Page. Display new headline, and prompt user for a guess
 router.get('/', function (req, response) {
-    getNewHeadline()
+    var headlineData = getNewHeadline()
     console.log("SubReddit: "+headlineData.subreddit)
     response.render('guessPage', {
         headline: headlineData.title, 
+        headlineID: headlineData.id,
         userScore: userScore
     });
 });
 
 //Result Page. Display result of the guess made by user
-router.post('/result', function(req, res) {
+router.post('/result/:headlineID', function(req, res) {
+    var headlineData = getHeadline(req.params.headlineID)
     console.log("SubReddit: "+headlineData.subreddit)
     console.log("Guess: "+req.body.guess)
     articleLink = headlineData.url
@@ -67,6 +76,7 @@ router.post('/result', function(req, res) {
     res.render('resultsPage', {
         result: resultText, 
         headline: headlineData.title,
+        headlineID: headlineData.id,        
         articleLink: articleLink, 
         redditLink: redditLink, 
         userScore: userScore});

--- a/views/guessPage.ejs
+++ b/views/guessPage.ejs
@@ -59,7 +59,7 @@
 					<table cellspacing="90px" align="center">
 						<tbody>
 							<tr>
-								<form method="post" action="/result">
+								<form method="post" action="/result/<%= headlineID %>">
 									<td><button type="submit" class="btn btn-success btn-lg" name="guess" value="nottheonion">REAL</button></td>
 									<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 									<td><button type="submit" class="btn btn-danger btn-lg" name="guess" value="TheOnion">FAKE</button></td>


### PR DESCRIPTION
This solution preserves (or should, this is just armchair coding and I haven't tested it yet) the article from request to request. It does this by changing headlineData so it is no longer a global variable but is instead created for each request: on the guess page, it is still created from the random function, and on the result page it is pulled from a dictionary of headlines. 

It still does not address the score being a global variable shared across all users.